### PR TITLE
Improve docs

### DIFF
--- a/lib/okta.ex
+++ b/lib/okta.ex
@@ -25,14 +25,16 @@ defmodule Okta do
       }
 
       case Okta.Users.create_user(client, profile) do
-        {:ok, %{"id" => id, "status" => status}, _env} -> update_user(%{okta_id: id, okta_status: status})
-        {:error, %{"errorSummary" => errorSummary}, _env} -> Logger.error(errorSummary)
+        {:ok, %{"id" => id, "status" => status}, _env} ->
+          update_user(%{okta_id: id, okta_status: status})
+        {:error, %{"errorSummary" => errorSummary}, _env} ->
+          Logger.error(errorSummary)
       end
 
   ## Installation
 
-  If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-  by adding `okta` to your list of dependencies in `mix.exs`:
+  If [available in Hex](https://hex.pm/docs/publish), the package can be
+  installed by adding `okta` to your list of dependencies in `mix.exs`:
 
       def deps do
         [

--- a/lib/okta.ex
+++ b/lib/okta.ex
@@ -6,42 +6,43 @@ defmodule Okta do
   * [Users API](https://developer.okta.com/docs/reference/api/users/)
   * [Groups API](https://developer.okta.com/docs/reference/api/groups/)
 
-  The API access uses the [Tesla](https://github.com/teamon/tesla) library and relies on the caller passing in an Okta base URL and an API Key
-  to create a client. The client is then passed into all API calls.
+  The API access uses the [Tesla](https://github.com/teamon/tesla) library and
+  relies on the caller passing in an Okta base URL and an API Key to create a
+  client. The client is then passed into all API calls.
 
-  The API returns a 3 element tuple. If the API HTTP status code is less the 300 (ie. suceeded) it returns `:ok`, the HTTP body as a map and the full Tesla Env if you need to access more data about thre return. if the API HTTP status code is greater than 300. it returns `:error`, the HTTP body and the Telsa Env. If the API doesn't return at all it should return `:error`, a blank map and the error from Tesla.
+  The API returns a 3 element tuple. If the API HTTP status code is less
+  the 300 (ie. suceeded) it returns `:ok`, the HTTP body as a map and the full
+  Tesla Env if you need to access more data about thre return. if the API HTTP
+  status code is greater than 300. it returns `:error`, the HTTP body and the
+  Telsa Env. If the API doesn't return at all it should return `:error`, a blank
+   map and the error from Tesla.
 
-  ```
-  client = Okta.client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
+      client = Okta.client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
 
-  profile = %{
-    firstName: "test",
-    lastName: "user",
-  }
+      profile = %{
+        firstName: "test",
+        lastName: "user",
+      }
 
-  case Okta.Users.create_user(client, profile) do
-  {:ok, %{"id" => id, "status" => status}, _env} -> update_user(%{okta_id: id, okta_status: status})
-  {:error, %{"errorSummary" => errorSummary}, _env} -> Logger.error(errorSummary)
-  end
-  ```
+      case Okta.Users.create_user(client, profile) do
+        {:ok, %{"id" => id, "status" => status}, _env} -> update_user(%{okta_id: id, okta_status: status})
+        {:error, %{"errorSummary" => errorSummary}, _env} -> Logger.error(errorSummary)
+      end
 
   ## Installation
 
   If [available in Hex](https://hex.pm/docs/publish), the package can be installed
   by adding `okta` to your list of dependencies in `mix.exs`:
 
-  ```
-  def deps do
-  [
-    {:okta_api, "~> 0.1.0"}
-  ]
-  end
-  ```
+      def deps do
+        [
+          {:okta_api, "~> 0.1.0"},
+        ]
+      end
 
   Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
   and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
   be found at [https://hexdocs.pm/okta](https://hexdocs.pm/okta_api).
-
   """
   @type client() :: Tesla.Client.t()
   @type result() :: {:ok, map(), Tesla.Env.t()} | {:error, map(), any}

--- a/lib/okta/groups.ex
+++ b/lib/okta/groups.ex
@@ -6,11 +6,9 @@ defmodule Okta.Groups do
 
   ## Examples
 
-  ```
-  client = Okta.Client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
+      client = Okta.Client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
+      {:ok, result, _env} = Okta.Groups.list_groups(client)
 
-  {:ok, result, _env} = Okta.Groups.list_groups(client)
-  ```
   """
   @type client() :: Tesla.Client.t()
   @type result() :: {:ok, map(), Tesla.Env.t()} | {:error, map(), any}
@@ -20,15 +18,16 @@ defmodule Okta.Groups do
   @doc """
   Adds a new group with OKTA_GROUP type to your organization.
 
-  The [OKTA group profile object](https://developer.okta.com/docs/reference/api/groups/#objectclass-okta-user-group) has a name and description attributes
+  The [OKTA group profile object](https://developer.okta.com/docs/reference/api/groups/#objectclass-okta-user-group)
+  has a name and description attributes.
 
   ## Examples
 
-  ```
-  client = Okta.Client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
 
-  {:ok, result} = Okta.Groups.create_group(client, %{name: "Designers", description: "All the designers"})
-  ```
+      client = Okta.Client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
+      {:ok, result} = Okta.Groups.create_group(client, %{
+        name: "Designers", description: "All the designers"
+      })
 
   [https://developer.okta.com/docs/reference/api/groups/#add-group](https://developer.okta.com/docs/reference/api/groups/#add-group)
   """
@@ -39,8 +38,8 @@ defmodule Okta.Groups do
 
   @doc """
   Updates the profile for a group with OKTA_GROUP type from your organization.
-  The [OKTA group profile object](https://developer.okta.com/docs/reference/api/groups/#objectclass-okta-user-group) has a name and description attributes
-
+  The [OKTA group profile object](https://developer.okta.com/docs/reference/api/groups/#objectclass-okta-user-group)
+  has a name and description attributes.
 
   [https://developer.okta.com/docs/reference/api/groups/#update-group](https://developer.okta.com/docs/reference/api/groups/#update-group)
   """
@@ -60,7 +59,7 @@ defmodule Okta.Groups do
   end
 
   @doc """
-  Fetches a specific group by id from your organization
+  Fetches a specific group by id from your organization.
 
   [https://developer.okta.com/docs/reference/api/groups/#get-group](https://developer.okta.com/docs/reference/api/groups/#get-group)
   """
@@ -70,7 +69,8 @@ defmodule Okta.Groups do
   end
 
   @doc """
-  Enumerates all users that are a member of a group. `limit` and `after` parameters provide for paging
+  Enumerates all users that are a member of a group. `limit` and `after`
+  parameters provide for paging.
 
   [https://developer.okta.com/docs/reference/api/groups/#list-group-members](https://developer.okta.com/docs/reference/api/groups/#list-group-members)
   """
@@ -112,18 +112,16 @@ defmodule Okta.Groups do
   @doc """
   Enumerates groups in your organization with pagination.
 
-  A subset of groups can be returned that match a supported filter expression or query.
+  A subset of groups can be returned that match a supported filter expression or
+  query.
 
   see
   [https://developer.okta.com/docs/reference/api/groups/#list-groups](https://developer.okta.com/docs/reference/api/groups/#list-groups)
-
-  for optional parameters that can be passed in
+  for optional parameters that can be passed in.
 
   ##Example
 
-  ```
-    {:ok, result} = Okta.Users.list_groups(client, q: "Design", limit: 10, after: 200)
-  ```
+      {:ok, result} = Okta.Users.list_groups(client, q: "Design", limit: 10, after: 200)
   """
   @spec list_groups(client(), keyword()) :: result()
   def list_groups(client, opts \\ []) do
@@ -141,7 +139,7 @@ defmodule Okta.Groups do
   end
 
   @doc """
-  Filter groups by expression
+  Filter groups by expression.
 
   see [https://developer.okta.com/docs/reference/api/groups/#list-groups](https://developer.okta.com/docs/reference/api/groups/#list-groups) and
   [https://developer.okta.com/docs/reference/api-overview/#filtering](https://developer.okta.com/docs/reference/api-overview/#filtering)
@@ -177,7 +175,8 @@ defmodule Okta.Groups do
   end
 
   @doc """
-  Enumerates all groups with user memberships updated after the specified timestamp.
+  Enumerates all groups with user memberships updated after the specified
+  timestamp.
 
   [https://developer.okta.com/docs/reference/api/groups/#list-groups-with-membership-updated-after-timestamp](https://developer.okta.com/docs/reference/api/groups/#list-groups-with-membership-updated-after-timestamp)
   """
@@ -191,7 +190,8 @@ defmodule Okta.Groups do
   end
 
   @doc """
-  Enumerates all groups with profile or user memberships updated after the specified timestamp.
+  Enumerates all groups with profile or user memberships updated after the
+  specified timestamp.
 
   [https://developer.okta.com/docs/reference/api/groups/#list-groups-updated-after-timestamp](https://developer.okta.com/docs/reference/api/groups/#list-groups-updated-after-timestamp)
   """

--- a/lib/okta/users.ex
+++ b/lib/okta/users.ex
@@ -6,11 +6,8 @@ defmodule Okta.Users do
 
   ## Examples
 
-  ```
-  client = Okta.Client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
-
-  {:ok, result, _env} = Okta.Users.list_users(client)
-  ```
+      client = Okta.Client("https://dev-000000.okta.com", "thisismykeycreatedinokta")
+      {:ok, result, _env} = Okta.Users.list_users(client)
   """
 
   @type client() :: Tesla.Client.t()
@@ -19,7 +16,8 @@ defmodule Okta.Users do
   @users_url "/api/v1/users"
 
   @doc """
-  Fetch a user by id, login, or login shortname if the short name is unambiguous.
+  Fetch a user by id, login, or login shortname if the short name is
+  unambiguous.
 
   [https://developer.okta.com/docs/reference/api/users/#get-user](https://developer.okta.com/docs/reference/api/users/#get-user)
   """
@@ -29,7 +27,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Fetches the current user linked to API token or session cookie
+  Fetches the current user linked to API token or session cookie.
 
   [https://developer.okta.com/docs/reference/api/users/#get-current-user](https://developer.okta.com/docs/reference/api/users/#get-current-user)
   """
@@ -39,7 +37,8 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Fetches appLinks for all direct or indirect (via group membership) assigned applications
+  Fetches appLinks for all direct or indirect (via group membership) assigned
+  applications.
 
   [https://developer.okta.com/docs/reference/api/users/#get-assigned-app-links](https://developer.okta.com/docs/reference/api/users/#get-assigned-app-links)
   """
@@ -49,7 +48,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Fetches the groups of which the user is a member
+  Fetches the groups of which the user is a member.
 
   [https://developer.okta.com/docs/reference/api/users/#get-user-s-groups](https://developer.okta.com/docs/reference/api/users/#get-user-s-groups)
   """
@@ -59,8 +58,9 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Removes all active identity provider sessions. This forces the user to authenticate on the next operation.
-  Optionally revokes OpenID Connect and OAuth refresh and access tokens issued to the user.
+  Removes all active identity provider sessions. This forces the user to
+  authenticate on the next operation. Optionally revokes OpenID Connect and
+  OAuth refresh and access tokens issued to the user.
 
   [https://developer.okta.com/docs/reference/api/users/#clear-user-sessions](https://developer.okta.com/docs/reference/api/users/#clear-user-sessions)
 
@@ -74,18 +74,17 @@ defmodule Okta.Users do
   @doc """
   Lists users in your organization with pagination in most cases
 
-  A subset of users can be returned that match a supported filter expression or search criteria.
+  A subset of users can be returned that match a supported filter expression or
+  search criteria.
 
   see
   [https://developer.okta.com/docs/reference/api/users/#list-users](https://developer.okta.com/docs/reference/api/users/#list-users)
-
-  for optional parameters that can be passed in
+  for optional parameters that can be passed in.
 
   ##Example
 
-  ```
-    {:ok, result} = Okta.Users.list_users(client, q: "Noah", limit: 10, after: 200)
-  ```
+      {:ok, result} = Okta.Users.list_users(client, q: "Noah", limit: 10, after: 200)
+
   """
   @spec list_users(client(), keyword()) :: result()
   def list_users(client, opts \\ []) do
@@ -95,7 +94,9 @@ defmodule Okta.Users do
   @doc """
   Shortcut method to use list_users with a `q` parameter.
 
-  Finds users who match the specified query with a simple lookup of users by name, for example when creating a people picker. The value of query is matched against firstName, lastName, or email.
+  Finds users who match the specified query with a simple lookup of users by
+  name, for example when creating a people picker. The value of query is matched
+  against firstName, lastName, or email.
 
   [https://developer.okta.com/docs/reference/api/users/#find-users](https://developer.okta.com/docs/reference/api/users/#find-users)
   """
@@ -105,11 +106,12 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Shortcut method to use list_users with a `search` parameter. Searches for users based on the properties specified in the search_term
+  Shortcut method to use list_users with a `search` parameter. Searches for
+  users based on the properties specified in the search_term.
 
   see
   [https://developer.okta.com/docs/reference/api/users/#list-users-with-search](https://developer.okta.com/docs/reference/api/users/#list-users-with-search)
-  for details
+  for details.
   """
   @spec search_users(client(), String.t(), keyword()) :: result()
   def search_users(client, search_term, opts \\ []) do
@@ -117,11 +119,12 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Shortcut method to use list_users with a `filter` parameter. Lists all users that match the filter criteria
+  Shortcut method to use list_users with a `filter` parameter. Lists all users
+  that match the filter criteria.
 
   see
   [https://developer.okta.com/docs/reference/api/users/#list-users-with-a-filter](https://developer.okta.com/docs/reference/api/users/#list-users-with-a-filter)
-  for details
+  for details.
 
   and [https://developer.okta.com/docs/reference/api-overview/#filtering](https://developer.okta.com/docs/reference/api-overview/#filtering) on how Okta supports filters
   """
@@ -131,7 +134,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Lists all active users. ie. Users that have a status of ACTIVE
+  Lists all active users. ie. Users that have a status of `ACTIVE`.
   """
   @spec list_active_users(client(), keyword()) :: result()
   def list_active_users(client, opts \\ []) do
@@ -139,7 +142,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Lists all staged users. ie. Users that have a status of STAGED
+  Lists all staged users. ie. Users that have a status of `STAGED`.
   """
   @spec list_staged_users(client(), keyword()) :: result()
   def list_staged_users(client, opts \\ []) do
@@ -147,7 +150,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Lists all password recovery users. ie. Users that have a status of RECOVERY
+  Lists all password recovery users. ie. Users that have a status of `RECOVERY`.
   """
   @spec list_recovery_users(client()) :: result()
   @spec list_recovery_users(client(), keyword()) :: result()
@@ -156,7 +159,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Lists all deprovisioned users. ie. Users that have a status of DEPROVISIONED
+  Lists all deprovisioned users. ie. Users that have a status of `DEPROVISIONED`.
   """
   @spec list_deprovisioned_users(client(), keyword()) :: result()
   def list_deprovisioned_users(client, opts \\ []) do
@@ -164,7 +167,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Lists all password expired users. ie. Users that have a status of PASSWORD_EXPIRED
+  Lists all password expired users. ie. Users that have a status of `PASSWORD_EXPIRED`.
   """
   @spec list_password_expired_users(client()) :: result()
   @spec list_password_expired_users(client(), keyword()) :: result()
@@ -173,7 +176,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Lists all provisioned users. ie. Users that have a status of PROVISIONED
+  Lists all provisioned users. ie. Users that have a status of `PROVISIONED`.
   """
   @spec list_provisioned_users(client(), keyword()) :: result()
   def list_provisioned_users(client, opts \\ []) do
@@ -181,7 +184,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Lists all locked out users. ie. Users that have a status of LOCKED_OUT
+  Lists all locked out users. ie. Users that have a status of `LOCKED_OUT`.
   """
   @spec list_locked_users(client(), keyword()) :: result()
   def list_locked_users(client, opts \\ []) do
@@ -201,7 +204,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Creates a new user in your Okta organization with or without credentials
+  Creates a new user in your Okta organization with or without credentials.
 
   [https://developer.okta.com/docs/reference/api/users/#create-user](https://developer.okta.com/docs/reference/api/users/#create-user)
   """
@@ -239,7 +242,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Creates a user without a recovery question & answer
+  Creates a user without a recovery question & answer.
 
   [https://developer.okta.com/docs/reference/api/users/#create-user-with-password](https://developer.okta.com/docs/reference/api/users/#create-user-with-password)
   """
@@ -254,7 +257,8 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Creates a new passwordless user with a SOCIAL or FEDERATION authentication provider that must be authenticated via a trusted Identity Provider
+  Creates a new passwordless user with a `SOCIAL` or `FEDERATION` authentication
+  provider that must be authenticated via a trusted Identity Provider.
 
   [https://developer.okta.com/docs/reference/api/users/#create-user-with-authentication-provider](https://developer.okta.com/docs/reference/api/users/#create-user-with-authentication-provider)
   """
@@ -282,7 +286,8 @@ defmodule Okta.Users do
   @doc """
   Sets passwords without validating existing user credentials
 
-  This is an administrative operation. For an operation that requires validation see `change_password/4`
+  This is an administrative operation. For an operation that requires validation
+  see `change_password/4`.
 
   [https://developer.okta.com/docs/reference/api/users/#set-password](https://developer.okta.com/docs/reference/api/users/#set-password)
 
@@ -296,7 +301,8 @@ defmodule Okta.Users do
   @doc """
   Changes a user's password by validating the user's current password
 
-  This operation can only be performed on users in STAGED, ACTIVE, PASSWORD_EXPIRED, or RECOVERY status that have a valid password credential
+  This operation can only be performed on users in `STAGED`, `ACTIVE`,
+  `PASSWORD_EXPIRED`, or `RECOVERY` status that have a valid password credential.
 
   [https://developer.okta.com/docs/reference/api/users/#change-password](https://developer.okta.com/docs/reference/api/users/#change-password)
   """
@@ -314,9 +320,10 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Sets recovery question and answer without validating existing user credentials
+  Sets recovery question and answer without validating existing user credentials.
 
-  This is an administrative operation. For an operation that requires validation see `change_recovery_credential/5`
+  This is an administrative operation. For an operation that requires validation
+  see `change_recovery_credential/5`
 
   [https://developer.okta.com/docs/reference/api/users/#set-recovery-question-answer](https://developer.okta.com/docs/reference/api/users/#set-recovery-question-answer)
   """
@@ -329,9 +336,11 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Changes a user's recovery question & answer credential by validating the user's current password
+  Changes a user's recovery question & answer credential by validating the
+  user's current password.
 
-  This operation can only be performed on users in STAGED, ACTIVE or RECOVERY status that have a valid password credential
+  This operation can only be performed on users in `STAGED`, `ACTIVE` or
+  `RECOVERY` status that have a valid password credential.
 
   [https://developer.okta.com/docs/reference/api/users/#change-recovery-question](https://developer.okta.com/docs/reference/api/users/#change-recovery-question)
   """
@@ -345,13 +354,17 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Activates a user
+  Activates a user.
 
-  This operation can only be performed on users with a STAGED status. Activation of a user is an asynchronous operation.
+  This operation can only be performed on users with a `STAGED` status.
+  Activation of a user is an asynchronous operation.
 
-  The user's transitioningToStatus property has a value of ACTIVE during activation to indicate that the user hasn't completed the asynchronous operation.
-  The user's status is ACTIVE when the activation process is complete.
-  Users who don't have a password must complete the welcome flow by visiting the activation link to complete the transition to ACTIVE status.
+  The user's transitioningToStatus property has a value of `ACTIVE` during
+  activation to indicate that the user hasn't completed the asynchronous
+  operation.
+  The user's status is `ACTIVE` when the activation process is complete.
+  Users who don't have a password must complete the welcome flow by visiting
+  the activation link to complete the transition to `ACTIVE` status.
 
   [https://developer.okta.com/docs/reference/api/users/#activate-user](https://developer.okta.com/docs/reference/api/users/#activate-user)
   """
@@ -367,11 +380,14 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Reactivates a user
+  Reactivates a user.
 
-  This operation can only be performed on users with a PROVISIONED status. This operation restarts the activation workflow if for some reason the user activation was not completed when using the activationToken from Activate User.
+  This operation can only be performed on users with a `PROVISIONED` status.
+  This operation restarts the activation workflow if for some reason the user
+  activation was not completed when using the `activationToken` from Activate User.
 
-  Users that don't have a password must complete the flow by completing Reset Password and MFA enrollment steps to transition the user to ACTIVE status.
+  Users that don't have a password must complete the flow by completing Reset
+  Password and MFA enrollment steps to transition the user to `ACTIVE` status.
 
   [https://developer.okta.com/docs/reference/api/users/#reactivate-user](https://developer.okta.com/docs/reference/api/users/#reactivate-user)
   """
@@ -387,13 +403,16 @@ defmodule Okta.Users do
   end
 
   @doc """
+  Deactivates a user.
 
-  Deactivates a user
+  This operation can only be performed on users that do not have a
+  `DEPROVISIONED` status. Deactivation of a user is an asynchronous operation.
 
-  This operation can only be performed on users that do not have a DEPROVISIONED status. Deactivation of a user is an asynchronous operation.
-
-  The user's transitioningToStatus property is DEPROVISIONED during deactivation to indicate that the user hasn't completed the asynchronous operation.
-  The user's status is DEPROVISIONED when the deactivation process is complete.
+  The user's transitioningToStatus property is `DEPROVISIONED` during
+  deactivation to indicate that the user hasn't completed the asynchronous
+  operation.
+  The user's status is `DEPROVISIONED` when the deactivation process is
+  complete.
 
   [https://developer.okta.com/docs/reference/api/users/#deactivate-user](https://developer.okta.com/docs/reference/api/users/#deactivate-user)
   """
@@ -406,7 +425,8 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Unlocks a user with a LOCKED_OUT status and returns them to ACTIVE status. Users will be able to login with their current password.
+  Unlocks a user with a `LOCKED_OUT` status and returns them to ACTIVE status.
+  Users will be able to login with their current password.
 
   [https://developer.okta.com/docs/reference/api/users/#unlock-user](https://developer.okta.com/docs/reference/api/users/#unlock-user)
   """
@@ -416,9 +436,12 @@ defmodule Okta.Users do
   end
 
   @doc """
-  This operation transitions the user status to PASSWORD_EXPIRED so that the user is required to change their password at their next login.
+  This operation transitions the user status to PASSWORD_EXPIRED so that the
+  user is required to change their password at their next login.
 
-  If tempPassword is included in the request, the user's password is reset to a temporary password that is returned, and then the temporary password is expired.
+  If tempPassword is included in the request, the user's password is reset to a
+  temporary password that is returned, and then the temporary password is
+  expired.
 
   [https://developer.okta.com/docs/reference/api/users/#expire-password](https://developer.okta.com/docs/reference/api/users/#expire-password)
   """
@@ -431,9 +454,13 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Generates a one-time token (OTT) that can be used to reset a user's password. The OTT link can be automatically emailed to the user or returned to the API caller and distributed using a custom flow.
+  Generates a one-time token (OTT) that can be used to reset a user's password.
+  The OTT link can be automatically emailed to the user or returned to the API
+  caller and distributed using a custom flow.
 
-  This operation will transition the user to the status of RECOVERY and the user will not be able to login or initiate a forgot password flow until they complete the reset flow.
+  This operation will transition the user to the status of `RECOVERY` and the
+  user will not be able to login or initiate a forgot password flow until they
+  complete the reset flow.
 
   [https://developer.okta.com/docs/reference/api/users/#reset-password](https://developer.okta.com/docs/reference/api/users/#reset-password)
   """
@@ -451,7 +478,8 @@ defmodule Okta.Users do
   @doc """
   Suspends a user
 
-  This operation can only be performed on users with an ACTIVE status. The user has a status of SUSPENDED when the process is complete.
+  This operation can only be performed on users with an `ACTIVE` status. The
+  user has a status of `SUSPENDED` when the process is complete.
 
 
   [https://developer.okta.com/docs/reference/api/users/#suspend-user](https://developer.okta.com/docs/reference/api/users/#suspend-user)
@@ -462,7 +490,7 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Unsuspends a user and returns them to the ACTIVE state
+  Unsuspends a user and returns them to the `ACTIVE` state.
 
   [https://developer.okta.com/docs/reference/api/users/#unsuspend-user](https://developer.okta.com/docs/reference/api/users/#unsuspend-user)
   """
@@ -472,7 +500,8 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Deletes a user permanently. This operation can only be performed on users that have a DEPROVISIONED status. This action cannot be recovered!
+  Deletes a user permanently. This operation can only be performed on users
+  that have a `DEPROVISIONED` status. This action cannot be recovered!.
 
   [https://developer.okta.com/docs/reference/api/users/#delete-user](https://developer.okta.com/docs/reference/api/users/#delete-user)
   """
@@ -483,10 +512,11 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Generates a one-time token (OTT) that can be used to reset a user's password
+  Generates a one-time token (OTT) that can be used to reset a user's password.
 
-  The user will be required to validate their security question's answer when visiting the reset link.
-  This operation can only be performed on users with an ACTIVE status and a valid recovery question credential.
+  The user will be required to validate their security question's answer when
+  visiting the reset link. This operation can only be performed on users with
+  an `ACTIVE` status and a valid recovery question credential.
 
   [https://developer.okta.com/docs/reference/api/users/#forgot-password](https://developer.okta.com/docs/reference/api/users/#forgot-password)
   """
@@ -502,7 +532,8 @@ defmodule Okta.Users do
   end
 
   @doc """
-  Sets a new password for a user by validating the user's answer to their current recovery question
+  Sets a new password for a user by validating the user's answer to their
+  current recovery question.
 
   [https://developer.okta.com/docs/reference/api/users/#forgot-password](https://developer.okta.com/docs/reference/api/users/#forgot-password)
   """


### PR DESCRIPTION
When you use `h/1` it doesn't actually support markdown so here are two tips

- Use 4 spaces over ``` for code's blocks.
- Try to keep the doc in 80 columns since this stuff can be rendered in terminals (where it is easier to scroll up and down but hard to do anything horizontal, especially in servers)
- Be careful with `[name](link)` since `h/1` will show the link as well, pretty much remove `[]` and `()`