### PR TITLE
Fix typespec

### DIFF
--- a/lib/okta/event_hook_handler.ex
+++ b/lib/okta/event_hook_handler.ex
@@ -9,5 +9,5 @@ defmodule Okta.EventHookHandler do
 
   @type event :: %{}
 
-  @callback handle_event(event :: event()) :: none()
+  @callback handle_event(event :: event()) :: any()
 end


### PR DESCRIPTION
Since we don't care what the user returns from the event handler we suppose to use `any()`.

`none()|no_returns()` suppose to raise an error, the dialyzer is giving me some error because of this.