### PR TITLE
Add mfa to secret key of event hook plug

### DIFF
--- a/lib/okta/plug/event_hook.ex
+++ b/lib/okta/plug/event_hook.ex
@@ -30,7 +30,8 @@ if Code.ensure_loaded?(Plug) do
     ### Configuration
 
     * `event_handler`: A module that implements `Okta.EventHookHandler` behaviour.
-    * `secret_key`: The secret key to validate the incoming requests.
+    * `secret_key`: The secret key to validate the incoming requests. You could
+    use `mfa` configuration as well.
     """
 
     @behaviour Plug
@@ -108,6 +109,13 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp secret_key(opts) do
+      case secret_key_from_opts(opts) do
+        {m, f, a} -> apply(m, f, a)
+        secret_key -> secret_key
+      end
+    end
+
+    defp secret_key_from_opts(opts) do
       Keyword.fetch!(opts, :secret_key)
     rescue
       _ ->


### PR DESCRIPTION
- Add `m,f,a` as configuration for the secret key.

This allows us to bypass compilation time for setting up the secret key