### PR TITLE
Fixing typespec to include lists

### DIFF
--- a/lib/okta.ex
+++ b/lib/okta.ex
@@ -50,7 +50,7 @@ defmodule Okta do
   be found at [https://hexdocs.pm/okta](https://hexdocs.pm/okta_api).
   """
   @type client() :: Tesla.Client.t()
-  @type result() :: {:ok, map() | String.t(), Tesla.Env.t()} | {:error, map(), any}
+  @type result() :: {:ok, map() | list(map()) | String.t(), Tesla.Env.t()} | {:error, map(), any}
 
   @spec client(String.t(), String.t()) :: client()
   def client(base_url, api_key) do


### PR DESCRIPTION
The requests follow a format of returning a list for queries, this updates the spec to adhere to it. https://developer.okta.com/docs/reference/api/groups/#request-example-3